### PR TITLE
feat: Add ParseObjectIdPipe for validating object IDs

### DIFF
--- a/src/pipes/parse-object-id-pipe.pipe.ts
+++ b/src/pipes/parse-object-id-pipe.pipe.ts
@@ -1,0 +1,15 @@
+import { PipeTransform, Injectable, BadRequestException } from '@nestjs/common';
+import mongoose from 'mongoose';
+
+@Injectable()
+export class ParseObjectIdPipe
+  implements PipeTransform<any, mongoose.Types.ObjectId>
+{
+  transform(value: any): mongoose.Types.ObjectId {
+    const validObjectId: boolean = mongoose.isObjectIdOrHexString(value);
+    if (!validObjectId) {
+      throw new BadRequestException('Invalid ObjectId');
+    }
+    return value;
+  }
+}

--- a/src/providers/providers.controller.ts
+++ b/src/providers/providers.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/commo
 import { ProvidersService } from './providers.service';
 import { CreateProviderDto } from './dto/create-provider.dto';
 import { UpdateProviderDto } from './dto/update-provider.dto';
+import { ParseObjectIdPipe } from '../pipes/parse-object-id-pipe.pipe';
 
 @Controller('providers')
 export class ProvidersController {
@@ -18,17 +19,17 @@ export class ProvidersController {
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string) {
+  findOne(@Param('id', ParseObjectIdPipe) id: string) {
     return this.providersService.findOne(id);
   }
 
   @Patch(':id')
-  update(@Param('id') id: string, @Body() updateProviderDto: UpdateProviderDto) {
+  update(@Param('id', ParseObjectIdPipe) id: string, @Body() updateProviderDto: UpdateProviderDto) {
     return this.providersService.update(id, updateProviderDto);
   }
 
   @Delete(':id')
-  remove(@Param('id') id: string) {
+  remove(@Param('id', ParseObjectIdPipe) id: string) {
     return this.providersService.remove(id);
   }
 }

--- a/src/recipes/recipes.controller.ts
+++ b/src/recipes/recipes.controller.ts
@@ -13,13 +13,14 @@ import { RecipesService } from './recipes.service';
 import { CreateRecipeDto } from './dto/create-recipe.dto';
 import { UpdateRecipeDto } from './dto/update-recipe.dto';
 import { FindByDto } from './dto/find-by.dto';
+import { ParseObjectIdPipe } from '../pipes/parse-object-id-pipe.pipe';
 
 @Controller('recipes')
 export class RecipesController {
   constructor(private readonly recipesService: RecipesService) {}
 
   @Get(':id')
-  async findOne(@Param('id') id: string) {
+  async findOne(@Param('id', ParseObjectIdPipe) id: string) {
     const recipe = await this.recipesService.findOne(id);
     if (!recipe) {
       throw new NotFoundException('Receta no encontrada');
@@ -45,12 +46,12 @@ export class RecipesController {
   }
 
   @Patch(':id')
-  update(@Param('id') id: string, @Body() updateRecipeDto: UpdateRecipeDto) {
+  update(@Param('id', ParseObjectIdPipe) id: string, @Body() updateRecipeDto: UpdateRecipeDto) {
     return this.recipesService.update(id, updateRecipeDto);
   }
 
   @Delete(':id')
-  remove(@Param('id') id: string) {
+  remove(@Param('id', ParseObjectIdPipe) id: string) {
     return this.recipesService.remove(id);
   }
 }

--- a/src/recipes/recipes.service.ts
+++ b/src/recipes/recipes.service.ts
@@ -3,8 +3,9 @@ import { CreateRecipeDto } from './dto/create-recipe.dto';
 import { UpdateRecipeDto } from './dto/update-recipe.dto';
 import { InjectModel } from '@nestjs/mongoose';
 import { Recipe } from './schemas/recipe.schema';
-import mongoose, { Model } from 'mongoose';
+import { Model } from 'mongoose';
 import { FindByDto } from './dto/find-by.dto';
+
 @Injectable()
 export class RecipesService {
   constructor(@InjectModel(Recipe.name) private recipeModel: Model<Recipe>) {}
@@ -19,7 +20,7 @@ export class RecipesService {
   }
 
   findOne(id: string) {
-    if (!mongoose.Types.ObjectId.isValid(id) || !id) {
+    if (!id) {
       return null;
     }
     return this.recipeModel.findOne({ _id: id });

--- a/src/supplies/supplies.controller.ts
+++ b/src/supplies/supplies.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/commo
 import { SuppliesService } from './supplies.service';
 import { CreateSupplyDto } from './dto/create-supply.dto';
 import { UpdateSupplyDto } from './dto/update-supply.dto';
+import { ParseObjectIdPipe } from '../pipes/parse-object-id-pipe.pipe';
 
 @Controller('supplies')
 export class SuppliesController {
@@ -18,17 +19,17 @@ export class SuppliesController {
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string) {
+  findOne(@Param('id', ParseObjectIdPipe) id: string) {
     return this.suppliesService.findOne(id);
   }
 
   @Patch(':id')
-  update(@Param('id') id: string, @Body() updateSupplyDto: UpdateSupplyDto) {
+  update(@Param('id', ParseObjectIdPipe) id: string, @Body() updateSupplyDto: UpdateSupplyDto) {
     return this.suppliesService.update(id, updateSupplyDto);
   }
 
   @Delete(':id')
-  remove(@Param('id') id: string) {
+  remove(@Param('id', ParseObjectIdPipe) id: string) {
     return this.suppliesService.remove(id);
   }
 }

--- a/src/supplies/supplies.service.ts
+++ b/src/supplies/supplies.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import mongoose, { Model } from 'mongoose';
+import { Model } from 'mongoose';
 import { CreateSupplyDto } from './dto/create-supply.dto';
 import { UpdateSupplyDto } from './dto/update-supply.dto';
 import { Supply } from './schemas/supply.schema';
@@ -19,7 +19,7 @@ export class SuppliesService {
   }
 
   findOne(id: string) {
-    if (!mongoose.Types.ObjectId.isValid(id) || !id) {
+    if (!id) {
       return null;
     }
     return this.supplyModel.findOne({ _id: id });

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -10,6 +10,7 @@ import {
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { ParseObjectIdPipe } from '../pipes/parse-object-id-pipe.pipe';
 
 @Controller('users')
 export class UsersController {
@@ -26,17 +27,17 @@ export class UsersController {
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string) {
+  findOne(@Param('id', ParseObjectIdPipe) id: string) {
     return this.usersService.findOne(id);
   }
 
   @Patch(':id')
-  update(@Param('id') id: string, @Body() updateUserDto: UpdateUserDto) {
+  update(@Param('id', ParseObjectIdPipe) id: string, @Body() updateUserDto: UpdateUserDto) {
     return this.usersService.update(id, updateUserDto);
   }
 
   @Delete(':id')
-  remove(@Param('id') id: string) {
+  remove(@Param('id', ParseObjectIdPipe) id: string) {
     return this.usersService.remove(id);
   }
 }


### PR DESCRIPTION
This commit adds a new `ParseObjectIdPipe` class to the `pipes` directory. This pipe is responsible for transforming a value into a valid `mongoose.Types.ObjectId`. It checks if the value is a valid object ID or hex string using the `mongoose.isObjectIdOrHexString` method. If the value is not valid, it throws a `BadRequestException` with the message "Invalid ObjectId".

The `ParseObjectIdPipe` is used in the `findOne`, `update`, and `remove` methods of the `ProvidersController`, `RecipesController`, `SuppliesController`, and `UsersController` to validate the `id` parameter before performing any operations.

This change improves the reliability and security of the application by ensuring that only valid object IDs are used in database operations.