### PR TITLE
feat: Remove unused entity classes and add update machine DTO

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { RecipesModule } from './recipes/recipes.module';
 import { SuppliesModule } from './supplies/supplies.module';
 import { ProvidersModule } from './providers/providers.module';
+import { MachinesModule } from './machines/machines.module';
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { ProvidersModule } from './providers/providers.module';
     RecipesModule,
     SuppliesModule,
     ProvidersModule,
+    MachinesModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/machines/dto/create-machine.dto.ts
+++ b/src/machines/dto/create-machine.dto.ts
@@ -1,0 +1,30 @@
+import {
+  IsString,
+  IsNotEmpty,
+  Length,
+  IsDate,
+  IsNumber,
+  IsMongoId,
+  IsDateString,
+} from 'class-validator';
+
+export class CreateMachineDto {
+  @IsString()
+  @IsNotEmpty()
+  @Length(1, 50)
+  name: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @Length(1, 500)
+  description: string;
+
+  @IsDateString()
+  purcharse_date: string;
+
+  @IsNumber()
+  desired_maintenance: number;
+
+  @IsMongoId()
+  user_id: string;
+}

--- a/src/machines/dto/update-machine.dto.ts
+++ b/src/machines/dto/update-machine.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateMachineDto } from './create-machine.dto';
+
+export class UpdateMachineDto extends PartialType(CreateMachineDto) {}

--- a/src/machines/machines.controller.spec.ts
+++ b/src/machines/machines.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MachinesController } from './machines.controller';
+import { MachinesService } from './machines.service';
+
+describe('MachinesController', () => {
+  let controller: MachinesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MachinesController],
+      providers: [MachinesService],
+    }).compile();
+
+    controller = module.get<MachinesController>(MachinesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/machines/machines.controller.ts
+++ b/src/machines/machines.controller.ts
@@ -1,0 +1,46 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+} from '@nestjs/common';
+import { MachinesService } from './machines.service';
+import { CreateMachineDto } from './dto/create-machine.dto';
+import { UpdateMachineDto } from './dto/update-machine.dto';
+import { ParseObjectIdPipe } from '../pipes/parse-object-id-pipe.pipe';
+
+@Controller('machines')
+export class MachinesController {
+  constructor(private readonly machinesService: MachinesService) {}
+
+  @Post()
+  create(@Body() createMachineDto: CreateMachineDto) {
+    return this.machinesService.create(createMachineDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.machinesService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id', ParseObjectIdPipe) id: string) {
+    return this.machinesService.findOne(id);
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id', ParseObjectIdPipe) id: string,
+    @Body() updateMachineDto: UpdateMachineDto,
+  ) {
+    return this.machinesService.update(id, updateMachineDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id', ParseObjectIdPipe) id: string) {
+    return this.machinesService.remove(id);
+  }
+}

--- a/src/machines/machines.module.ts
+++ b/src/machines/machines.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { MachinesService } from './machines.service';
+import { MachinesController } from './machines.controller';
+import { Machine, MachineSchema } from './schemas/machine.schema';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: Machine.name, schema: MachineSchema }]),
+  ],
+  controllers: [MachinesController],
+  providers: [MachinesService],
+})
+export class MachinesModule {}

--- a/src/machines/machines.service.spec.ts
+++ b/src/machines/machines.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MachinesService } from './machines.service';
+
+describe('MachinesService', () => {
+  let service: MachinesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MachinesService],
+    }).compile();
+
+    service = module.get<MachinesService>(MachinesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/machines/machines.service.ts
+++ b/src/machines/machines.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { CreateMachineDto } from './dto/create-machine.dto';
+import { UpdateMachineDto } from './dto/update-machine.dto';
+import { Machine } from './schemas/machine.schema';
+
+@Injectable()
+export class MachinesService {
+  constructor(
+    @InjectModel(Machine.name) private machineModel: Model<Machine>,
+  ) {}
+
+  create(createMachineDto: CreateMachineDto) {
+    const machine = new this.machineModel(createMachineDto);
+    return machine.save();
+  }
+
+  findAll(): Promise<Machine[]> {
+    return this.machineModel.find().populate('user_id').exec();
+  }
+
+  findOne(id: string): Promise<Machine> {
+    return this.machineModel.findById(id).populate('user_id').exec();
+  }
+
+  async update(id: string, updateMachineDto: UpdateMachineDto) {
+    const machine = await this.findOne(id);
+    Object.assign(machine, updateMachineDto);
+    return this.machineModel.updateOne(machine);
+  }
+
+  async remove(id: string) {
+    const machine = await this.findOne(id);
+    return this.machineModel.deleteOne(machine);
+  }
+}

--- a/src/machines/requests.http
+++ b/src/machines/requests.http
@@ -1,0 +1,24 @@
+### POST MAQUINARIA
+POST http://localhost:3000/machines HTTP/1.1
+content-type: application/json
+
+{
+    "name": "amasadora 1",
+    "description": "amasadora de 10kg",
+    "purcharse_date": "2021-01-01",
+    "desired_maintenance": 3,
+    "user_id": "6659d6c240e489a6515d6396"
+}
+### GET ALL MAQUINARIA
+GET http://localhost:3000/machines HTTP/1.1
+### GET POR ID MAQUINARIA
+GET http://localhost:3000/machines/6681d8ec3ba45a93828f4670 HTTP/1.1
+### PUT MAQUINARIA
+PATCH http://localhost:3000/machines/6681d8ec3ba45a93828f4670 HTTP/1.1
+content-type: application/json
+
+{
+    "name": "amasadora 2"
+}
+### DELETE MAQUINARIA
+DELETE http://localhost:3000/machines/6681d8ec3ba45a93828f4670 HTTP/1.1

--- a/src/machines/schemas/machine.schema.ts
+++ b/src/machines/schemas/machine.schema.ts
@@ -1,0 +1,34 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument } from 'mongoose';
+import { User } from 'src/users/schemas/user.schema';
+
+export type MachineDocument = HydratedDocument<Machine>;
+
+@Schema()
+export class Machine {
+  @Prop()
+  name: string;
+
+  @Prop()
+  description: string;
+
+  @Prop()
+  purcharse_date: Date;
+
+  @Prop()
+  last_maintenance_date: string;
+
+  @Prop()
+  desired_maintenance: number;
+
+  @Prop()
+  createdAt: Date;
+
+  @Prop()
+  updatedAt: Date;
+
+  @Prop({ type: 'ObjectId', ref: 'User' })
+  user_id: User;
+}
+
+export const MachineSchema = SchemaFactory.createForClass(Machine);

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,9 @@ import { NestExpressApplication } from '@nestjs/platform-express';
 import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
-  const app = await NestFactory.create<NestExpressApplication>(AppModule, { cors: true });
+  const app = await NestFactory.create<NestExpressApplication>(AppModule, {
+    cors: true,
+  });
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,

--- a/src/providers/dto/create-provider.dto.ts
+++ b/src/providers/dto/create-provider.dto.ts
@@ -5,6 +5,7 @@ import {
   IsEmail,
   IsUrl,
   Length,
+  IsMongoId,
 } from 'class-validator';
 
 export class CreateProviderDto {
@@ -22,9 +23,8 @@ export class CreateProviderDto {
   @IsNotEmpty()
   email: string;
 
-  @IsString()
-  @IsNotEmpty()
-  supplies: string;
+  @IsMongoId({ each: true })
+  supplies: string[];
 
   @IsUrl()
   @IsOptional()

--- a/src/providers/entities/provider.entity.ts
+++ b/src/providers/entities/provider.entity.ts
@@ -1,1 +1,0 @@
-export class Provider {}

--- a/src/providers/providers.controller.ts
+++ b/src/providers/providers.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+} from '@nestjs/common';
 import { ProvidersService } from './providers.service';
 import { CreateProviderDto } from './dto/create-provider.dto';
 import { UpdateProviderDto } from './dto/update-provider.dto';
@@ -24,7 +32,10 @@ export class ProvidersController {
   }
 
   @Patch(':id')
-  update(@Param('id', ParseObjectIdPipe) id: string, @Body() updateProviderDto: UpdateProviderDto) {
+  update(
+    @Param('id', ParseObjectIdPipe) id: string,
+    @Body() updateProviderDto: UpdateProviderDto,
+  ) {
     return this.providersService.update(id, updateProviderDto);
   }
 

--- a/src/providers/providers.service.ts
+++ b/src/providers/providers.service.ts
@@ -7,7 +7,9 @@ import { Provider } from './schemas/provider.schema';
 
 @Injectable()
 export class ProvidersService {
-  constructor(@InjectModel(Provider.name) private providerModel: Model<Provider>) {}
+  constructor(
+    @InjectModel(Provider.name) private providerModel: Model<Provider>,
+  ) {}
 
   create(createProviderDto: CreateProviderDto) {
     const provider = new this.providerModel(createProviderDto);
@@ -15,11 +17,11 @@ export class ProvidersService {
   }
 
   findAll() {
-    return this.providerModel.find();
+    return this.providerModel.find().populate('supplies').exec();
   }
 
   findOne(id: string) {
-    return this.providerModel.findOne({ _id: id });
+    return this.providerModel.findOne({ _id: id }).populate('supplies').exec();
   }
 
   async update(id: string, updateProviderDto: UpdateProviderDto) {

--- a/src/providers/requests.http
+++ b/src/providers/requests.http
@@ -1,0 +1,23 @@
+### POST PROVEEDORES
+POST http://localhost:3000/providers HTTP/1.1
+content-type: application/json
+
+{
+    "name": "prueba 1",
+    "phone": "123456789",
+    "email": "asd@asd.com",
+    "supplies": ["6682e1ffbc32d9f674079daf", "6682e20fbc32d9f674079db1"]
+}
+### GET ALL PROVEEDORES
+GET http://localhost:3000/providers HTTP/1.1
+### GET POR ID PROVEEDORES
+GET http://localhost:3000/providers/6682e25101ac30ecb1e055a2 HTTP/1.1
+### PUT PROVEEDORES
+PATCH http://localhost:3000/providers/6682e25101ac30ecb1e055a2 HTTP/1.1
+content-type: application/json
+
+{
+    "named": "bimbo"
+}
+### DELETE PROVEEDORES
+DELETE http://localhost:3000/providers/6681d8ec3ba45a93828f4670 HTTP/1.1

--- a/src/providers/schemas/provider.schema.ts
+++ b/src/providers/schemas/provider.schema.ts
@@ -1,5 +1,6 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { HydratedDocument } from 'mongoose';
+import { Supply } from '../../supplies/schemas/supply.schema';
 
 export type ProviderDocument = HydratedDocument<Provider>;
 
@@ -14,8 +15,8 @@ export class Provider {
   @Prop()
   email: string;
 
-  @Prop()
-  supplies: string;
+  @Prop([{ type: 'ObjectId', ref: 'Supply' }])
+  supplies: Supply[];
 
   @Prop()
   image: string;

--- a/src/recipes/dto/create-recipe.dto.ts
+++ b/src/recipes/dto/create-recipe.dto.ts
@@ -1,4 +1,11 @@
-import { IsString, IsOptional, IsNumber, Length } from 'class-validator';
+import {
+  IsString,
+  IsOptional,
+  IsNumber,
+  Length,
+  IsMongoId,
+  IsNotEmpty,
+} from 'class-validator';
 
 export class CreateRecipeDto {
   @IsString()
@@ -26,4 +33,8 @@ export class CreateRecipeDto {
 
   @IsNumber()
   standardUnits: number;
+
+  @IsNotEmpty()
+  @IsMongoId({ each: true })
+  supplies: string[];
 }

--- a/src/recipes/dto/update-recipe.dto.ts
+++ b/src/recipes/dto/update-recipe.dto.ts
@@ -3,31 +3,31 @@ import { CreateRecipeDto } from './create-recipe.dto';
 import { IsNumber, IsOptional, IsString } from 'class-validator';
 
 export class UpdateRecipeDto extends PartialType(CreateRecipeDto) {
-    @IsOptional()
-    @IsString()
-    name: string;
-  
-    @IsOptional()
-    @IsString()
-    ingredients: string[];
-  
-    @IsOptional()
-    @IsString()
-    steps: string;
-  
-    @IsOptional()
-    @IsString()
-    author: string;
-  
-    @IsOptional()
-    @IsString()
-    recommendations: string;
-  
-    @IsOptional()
-    @IsString()
-    image: string;
-  
-    @IsOptional()
-    @IsNumber()
-    standardUnits: number;
+  @IsOptional()
+  @IsString()
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  ingredients: string[];
+
+  @IsOptional()
+  @IsString()
+  steps: string;
+
+  @IsOptional()
+  @IsString()
+  author: string;
+
+  @IsOptional()
+  @IsString()
+  recommendations: string;
+
+  @IsOptional()
+  @IsString()
+  image: string;
+
+  @IsOptional()
+  @IsNumber()
+  standardUnits: number;
 }

--- a/src/recipes/recipes.controller.ts
+++ b/src/recipes/recipes.controller.ts
@@ -46,7 +46,10 @@ export class RecipesController {
   }
 
   @Patch(':id')
-  update(@Param('id', ParseObjectIdPipe) id: string, @Body() updateRecipeDto: UpdateRecipeDto) {
+  update(
+    @Param('id', ParseObjectIdPipe) id: string,
+    @Body() updateRecipeDto: UpdateRecipeDto,
+  ) {
     return this.recipesService.update(id, updateRecipeDto);
   }
 

--- a/src/recipes/recipes.service.ts
+++ b/src/recipes/recipes.service.ts
@@ -16,14 +16,14 @@ export class RecipesService {
   }
 
   findAll() {
-    return this.recipeModel.find();
+    return this.recipeModel.find().populate('supplies').exec();
   }
 
   findOne(id: string) {
     if (!id) {
       return null;
     }
-    return this.recipeModel.findOne({ _id: id });
+    return this.recipeModel.findOne({ _id: id }).populate('supplies').exec();
   }
 
   findBy(query: FindByDto) {

--- a/src/recipes/schemas/recipe.schema.ts
+++ b/src/recipes/schemas/recipe.schema.ts
@@ -1,5 +1,6 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { HydratedDocument } from 'mongoose';
+import { Supply } from '../../supplies/schemas/supply.schema';
 
 export type RecipeDocument = HydratedDocument<Recipe>;
 
@@ -8,8 +9,8 @@ export class Recipe {
   @Prop()
   name: string;
 
-  @Prop()
-  ingredients: string;
+  @Prop([{ type: 'ObjectId', ref: 'Supply' }])
+  supplies: Supply[];
 
   @Prop()
   steps: string;
@@ -35,7 +36,7 @@ export class Recipe {
   @Prop({ default: Date.now })
   createdAt: Date;
 
-  @Prop()
+  @Prop({ default: Date.now })
   updatedAt: Date;
 }
 

--- a/src/supplies/dto/create-supply.dto.ts
+++ b/src/supplies/dto/create-supply.dto.ts
@@ -19,9 +19,8 @@ export class CreateSupplyDto {
   @Length(3, 1000)
   description: string;
 
-  @IsNotEmpty()
+  @IsOptional()
   @IsString()
-  @Length(3, 50)
   usedIn: string[];
 
   @IsNotEmpty()
@@ -36,12 +35,15 @@ export class CreateSupplyDto {
 
   @IsNotEmpty()
   @IsString()
-  @Length(3, 50)
   unit: string;
 
   @IsNotEmpty()
   @IsNumber()
   size: string;
+
+  @IsOptional()
+  @IsString()
+  type: string;
 
   @IsOptional()
   @IsUrl()

--- a/src/supplies/entities/supply.entity.ts
+++ b/src/supplies/entities/supply.entity.ts
@@ -1,1 +1,0 @@
-export class Supply {}

--- a/src/supplies/requests.http
+++ b/src/supplies/requests.http
@@ -1,0 +1,26 @@
+### POST INSUMOS
+POST http://localhost:3000/supplies HTTP/1.1
+content-type: application/json
+
+{
+    "name": "prueba 2",
+    "description": "prueba 1",
+    "min_stock": 1,
+    "max_stock": 1,
+    "unit": "kg",
+    "size": 1,
+    "usedIn": "asdasdas"
+}
+### GET ALL INSUMOS
+GET http://localhost:3000/supplies HTTP/1.1
+### GET POR ID INSUMOS
+GET http://localhost:3000/supplies/6681d8ec3ba45a93828f4670 HTTP/1.1
+### PUT INSUMOS
+PATCH http://localhost:3000/supplies/6681d8ec3ba45a93828f4670 HTTP/1.1
+content-type: application/json
+
+{
+    "name": "amasadora 2"
+}
+### DELETE INSUMOS
+DELETE http://localhost:3000/supplies/6681d8ec3ba45a93828f4670 HTTP/1.1

--- a/src/supplies/schemas/supply.schema.ts
+++ b/src/supplies/schemas/supply.schema.ts
@@ -1,5 +1,6 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { HydratedDocument } from 'mongoose';
+import { Recipe } from '../../recipes/schemas/recipe.schema';
 
 export type SupplyDocument = HydratedDocument<Supply>;
 
@@ -14,8 +15,8 @@ export class Supply {
   @Prop()
   type: string;
 
-  @Prop()
-  usedIn: string[];
+  @Prop([{ type: 'ObjectId', ref: 'Recipe' }])
+  usedIn: Recipe[];
 
   @Prop()
   min_stock: number;

--- a/src/supplies/supplies.controller.ts
+++ b/src/supplies/supplies.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+} from '@nestjs/common';
 import { SuppliesService } from './supplies.service';
 import { CreateSupplyDto } from './dto/create-supply.dto';
 import { UpdateSupplyDto } from './dto/update-supply.dto';
@@ -24,7 +32,10 @@ export class SuppliesController {
   }
 
   @Patch(':id')
-  update(@Param('id', ParseObjectIdPipe) id: string, @Body() updateSupplyDto: UpdateSupplyDto) {
+  update(
+    @Param('id', ParseObjectIdPipe) id: string,
+    @Body() updateSupplyDto: UpdateSupplyDto,
+  ) {
     return this.suppliesService.update(id, updateSupplyDto);
   }
 

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -32,7 +32,10 @@ export class UsersController {
   }
 
   @Patch(':id')
-  update(@Param('id', ParseObjectIdPipe) id: string, @Body() updateUserDto: UpdateUserDto) {
+  update(
+    @Param('id', ParseObjectIdPipe) id: string,
+    @Body() updateUserDto: UpdateUserDto,
+  ) {
     return this.usersService.update(id, updateUserDto);
   }
 


### PR DESCRIPTION
The commit removes the unused `Supply` and `Provider` entity classes from the codebase.

Additionally, the commit adds a new `UpdateMachineDto` class to the `machines/dto` directory. This DTO class is used for updating machine data and is a partial type of the `CreateMachineDto` class. It allows for updating only specific fields of a machine without requiring all the fields to be present.

These changes improve the codebase by removing unused code and providing a more flexible way to update machine data.

Added refs.