### PR TITLE
feat: Add table template for supplies in PDF generation

### DIFF
--- a/helpers/handlebars.ts
+++ b/helpers/handlebars.ts
@@ -20,11 +20,17 @@ hbs.registerHelper('today', function () {
   });
 });
 
-export const generatePdf = ({ title, user, data, headers }) => {
+export const generatePdf = ({ title, user, data, headers, tableTemplate }) => {
   const templateHtml = readFileSync(
     join(process.cwd(), 'views/index.hbs'),
     'utf8',
   );
+  const tableTemplateHtml = readFileSync(
+    join(process.cwd(), `views/${tableTemplate}.hbs`),
+    'utf8',
+  );
+
+  hbs.registerPartial('tableBody', tableTemplateHtml);
 
   const template = hbs.compile(templateHtml);
   const html = template({

--- a/src/auth/auth.guard.ts
+++ b/src/auth/auth.guard.ts
@@ -37,7 +37,7 @@ export class AuthGuard implements CanActivate {
         secret: this.configService.get<string>('JWT_SECRET'),
       });
 
-      request['user'] = payload;
+      request.user = payload;
     } catch {
       throw new UnauthorizedException();
     }

--- a/src/recipes/schemas/recipe.schema.ts
+++ b/src/recipes/schemas/recipe.schema.ts
@@ -1,6 +1,7 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { HydratedDocument } from 'mongoose';
 import { Supply } from '../../supplies/schemas/supply.schema';
+import { User } from 'src/users/schemas/user.schema';
 
 export type RecipeDocument = HydratedDocument<Recipe>;
 
@@ -12,11 +13,11 @@ export class Recipe {
   @Prop([{ type: 'ObjectId', ref: 'Supply' }])
   supplies: Supply[];
 
-  @Prop()
-  steps: string;
+  @Prop({ type: 'ObjectId', ref: 'User' })
+  author: User;
 
   @Prop()
-  author: string;
+  steps: string;
 
   @Prop()
   recommendations: string;

--- a/src/supplies/supplies.controller.ts
+++ b/src/supplies/supplies.controller.ts
@@ -6,19 +6,57 @@ import {
   Patch,
   Param,
   Delete,
+  Header,
+  Res,
 } from '@nestjs/common';
+import { Response } from 'express';
 import { SuppliesService } from './supplies.service';
 import { CreateSupplyDto } from './dto/create-supply.dto';
 import { UpdateSupplyDto } from './dto/update-supply.dto';
 import { ParseObjectIdPipe } from '../pipes/parse-object-id-pipe.pipe';
+import { PdfService } from 'src/pdf/pdf.service';
+import { Public } from '../auth/decorators/public.decorator';
+import { generatePdf } from '../../helpers/handlebars';
 
 @Controller('supplies')
 export class SuppliesController {
-  constructor(private readonly suppliesService: SuppliesService) {}
+  constructor(private readonly suppliesService: SuppliesService, private readonly pdfService: PdfService) {}
 
   @Post()
   create(@Body() createSupplyDto: CreateSupplyDto) {
     return this.suppliesService.create(createSupplyDto);
+  }
+
+  @Get('generate-pdf')
+  @Header('Content-Type', 'application/pdf')
+  @Header('Content-Disposition', 'attachment; filename="supplies.pdf"')
+  @Public()
+  async generatePdf(@Res() res: Response): Promise<void> {
+    const supplies = await this.suppliesService.findAll();
+
+    const html = generatePdf({
+      title: 'Lista de Recetas',
+      user: 'John Doe',
+      data: supplies,
+      headers: [
+        'Nombre',
+        'Fecha de ultima carga',
+        'Stock actual',
+        'Descripción',
+      ],
+      tableTemplate: 'supplies',
+    });
+
+    const buffer = await this.pdfService.generate(html);
+
+    res.set({
+      'Content-Length': buffer.length,
+      'Cache-Control': 'no-cache, no-store, must-revalidate',
+      Pragma: 'no-cache',
+      Expires: 0,
+    });
+
+    res.end(buffer);
   }
 
   @Get()

--- a/src/supplies/supplies.module.ts
+++ b/src/supplies/supplies.module.ts
@@ -3,12 +3,13 @@ import { SuppliesService } from './supplies.service';
 import { SuppliesController } from './supplies.controller';
 import { MongooseModule } from '@nestjs/mongoose';
 import { Supply, SupplySchema } from './schemas/supply.schema';
+import { PdfService } from 'src/pdf/pdf.service';
 
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: Supply.name, schema: SupplySchema }]),
   ],
   controllers: [SuppliesController],
-  providers: [SuppliesService],
+  providers: [SuppliesService, PdfService],
 })
 export class SuppliesModule {}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -9,7 +9,6 @@ import {
   Header,
   Res,
 } from '@nestjs/common';
-import puppeteer from 'puppeteer';
 import { Response } from 'express';
 
 import { UsersService } from './users.service';
@@ -38,7 +37,7 @@ export class UsersController {
 
   @Get('generate-pdf')
   @Header('Content-Type', 'application/pdf')
-  @Header('Content-Disposition', 'attachment; filename="filename.pdf"')
+  @Header('Content-Disposition', 'attachment; filename="users.pdf"')
   @Public()
   async generatePdf(@Res() res: Response): Promise<void> {
     const users = await this.usersService.findAll();
@@ -55,6 +54,7 @@ export class UsersController {
         'Fecha de Creación',
         'Último inicio',
       ],
+      tableTemplate: 'users',
     });
 
     const buffer = await this.pdfService.generate(html);

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -38,22 +38,7 @@
             {{/each}}
           </tr>
         </thead>
-        <tbody>
-          {{#each data}}
-            <tr>
-              <td>{{fullname}}</td>
-              <td>{{email}}</td>
-              {{#if state}}
-                <td>Activo</td>
-              {{else}}
-                <td>Inactivo</td>
-              {{/if}}
-              <td>{{type}}</td>
-              <td>{{formatDate createdAt}}</td>
-              <td>{{formatDate lastSession}}</td>
-            </tr>
-          {{/each}}
-        </tbody>
+          {{> tableBody}}
       </table>
     </div>
     <script

--- a/views/supplies.hbs
+++ b/views/supplies.hbs
@@ -1,0 +1,11 @@
+<tbody>
+  {{#each data}}
+    <tr>
+      <td>{{name}}</td>
+      <td></td>
+      <td>{{type}}</td>
+      <td>{{formatDate createdAt}}</td>
+      <td>{{formatDate lastSession}}</td>
+    </tr>
+  {{/each}}
+</tbody>

--- a/views/users.hbs
+++ b/views/users.hbs
@@ -1,0 +1,16 @@
+<tbody>
+  {{#each data}}
+    <tr>
+      <td>{{fullname}}</td>
+      <td>{{email}}</td>
+      {{#if state}}
+        <td>Activo</td>
+      {{else}}
+        <td>Inactivo</td>
+      {{/if}}
+      <td>{{type}}</td>
+      <td>{{formatDate createdAt}}</td>
+      <td>{{formatDate lastSession}}</td>
+    </tr>
+  {{/each}}
+</tbody>


### PR DESCRIPTION
The code changes in `helpers/handlebars.ts` add a new table template for supplies in the PDF generation process. This template, located in `views/supplies.hbs`, defines the structure and content of the table rows for supplies data. The addition of this template enhances the flexibility and customization options for generating PDFs with supplies information.