### PR TITLE
feat: Add UpdateMaintenanceDto for partial updates

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,7 @@ import { MachinesModule } from './machines/machines.module';
 import { AuthModule } from './auth/auth.module';
 import { PdfService } from './pdf/pdf.service';
 import { BatchModule } from './batch/batch.module';
+import { MaintenanceModule } from './maintenance/maintenance.module';
 
 @Module({
   imports: [
@@ -35,6 +36,7 @@ import { BatchModule } from './batch/batch.module';
     MachinesModule,
     AuthModule,
     BatchModule,
+    MaintenanceModule,
   ],
   providers: [PdfService],
 })

--- a/src/maintenance/dto/create-maintenance.dto.ts
+++ b/src/maintenance/dto/create-maintenance.dto.ts
@@ -1,0 +1,12 @@
+import { IsString, IsDateString, IsMongoId } from 'class-validator';
+
+export class CreateMaintenanceDto {
+  @IsString()
+  description: string;
+
+  @IsDateString()
+  date: string;
+
+  @IsMongoId()
+  machine: string;
+}

--- a/src/maintenance/dto/update-maintenance.dto.ts
+++ b/src/maintenance/dto/update-maintenance.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateMaintenanceDto } from './create-maintenance.dto';
+
+export class UpdateMaintenanceDto extends PartialType(CreateMaintenanceDto) {}

--- a/src/maintenance/maintenance.controller.spec.ts
+++ b/src/maintenance/maintenance.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MaintenanceController } from './maintenance.controller';
+import { MaintenanceService } from './maintenance.service';
+
+describe('MaintenanceController', () => {
+  let controller: MaintenanceController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MaintenanceController],
+      providers: [MaintenanceService],
+    }).compile();
+
+    controller = module.get<MaintenanceController>(MaintenanceController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/maintenance/maintenance.controller.ts
+++ b/src/maintenance/maintenance.controller.ts
@@ -1,0 +1,59 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  NotFoundException,
+} from '@nestjs/common';
+import { MaintenanceService } from './maintenance.service';
+import { CreateMaintenanceDto } from './dto/create-maintenance.dto';
+import { UpdateMaintenanceDto } from './dto/update-maintenance.dto';
+import { ParseObjectIdPipe } from '../pipes/parse-object-id-pipe.pipe';
+import { MachinesService } from '../machines/machines.service';
+import { CurrentUser } from '../users/decorators/current-user.decorator';
+import { User } from '../users/schemas/user.schema';
+
+@Controller('maintenance')
+export class MaintenanceController {
+  constructor(
+    private readonly maintenanceService: MaintenanceService,
+    private readonly machineService: MachinesService,
+  ) {}
+
+  @Post()
+  async create(@Body() createMaintenanceDto: CreateMaintenanceDto, @CurrentUser() user: User) {
+    const machine = await this.machineService.findOne(createMaintenanceDto.machine);
+    if (!machine) {
+      throw new NotFoundException('Machine not found');
+    }
+    const maintenance = await this.maintenanceService.create(createMaintenanceDto, user);
+    await this.machineService.addMaintenance(machine, maintenance);
+    return maintenance;
+  }
+
+  @Get()
+  findAll() {
+    return this.maintenanceService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id', ParseObjectIdPipe) id: string) {
+    return this.maintenanceService.findOne(id);
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id', ParseObjectIdPipe) id: string,
+    @Body() updateMaintenanceDto: UpdateMaintenanceDto,
+  ) {
+    return this.maintenanceService.update(id, updateMaintenanceDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id', ParseObjectIdPipe) id: string) {
+    return this.maintenanceService.remove(id);
+  }
+}

--- a/src/maintenance/maintenance.module.ts
+++ b/src/maintenance/maintenance.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { MaintenanceService } from './maintenance.service';
+import { MaintenanceController } from './maintenance.controller';
+import { MongooseModule } from '@nestjs/mongoose';
+import { Maintenance, MaintenanceSchema } from './schemas/maintenance.schema';
+import { MachinesModule } from 'src/machines/machines.module';
+
+@Module({
+  imports: [
+    MachinesModule,
+    MongooseModule.forFeature([{ name: Maintenance.name, schema: MaintenanceSchema }]),
+  ],
+  controllers: [MaintenanceController],
+  providers: [MaintenanceService],
+})
+export class MaintenanceModule {}

--- a/src/maintenance/maintenance.service.spec.ts
+++ b/src/maintenance/maintenance.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MaintenanceService } from './maintenance.service';
+
+describe('MaintenanceService', () => {
+  let service: MaintenanceService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MaintenanceService],
+    }).compile();
+
+    service = module.get<MaintenanceService>(MaintenanceService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/maintenance/maintenance.service.ts
+++ b/src/maintenance/maintenance.service.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@nestjs/common';
+import { CreateMaintenanceDto } from './dto/create-maintenance.dto';
+import { UpdateMaintenanceDto } from './dto/update-maintenance.dto';
+import { InjectModel } from '@nestjs/mongoose';
+import { Maintenance } from './schemas/maintenance.schema';
+import { Model } from 'mongoose';
+
+@Injectable()
+export class MaintenanceService {
+  constructor(
+    @InjectModel(Maintenance.name) private maintenanceModel: Model<Maintenance>,
+  ) {}
+  
+  create(createMaintenanceDto: CreateMaintenanceDto, user: any) {
+    const maintenance = new this.maintenanceModel(createMaintenanceDto);
+    maintenance.user = user._id;
+    return maintenance.save();
+  }
+
+  findAll(): Promise<Maintenance[]> {
+    return this.maintenanceModel.find();
+  }
+
+  findOne(id: string) {
+    return this.maintenanceModel.findById(id);
+  }
+
+  async update(id: string, updateMaintenanceDto: UpdateMaintenanceDto) {
+    const maintenance = await this.findOne(id);
+    if (!maintenance) {
+      return null;
+    }
+    Object.assign(maintenance, updateMaintenanceDto);
+    return maintenance.save();
+  }
+
+  async remove(id: string) {
+    const maintenance = await this.findOne(id);
+    if (!maintenance) {
+      return null;
+    }
+    return this.maintenanceModel.deleteOne({ _id: id });
+  }
+}

--- a/src/maintenance/schemas/maintenance.schema.ts
+++ b/src/maintenance/schemas/maintenance.schema.ts
@@ -1,0 +1,23 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument } from 'mongoose';
+import { User } from 'src/users/schemas/user.schema';
+import { Machine } from '../../machines/schemas/machine.schema';
+
+export type MaintenanceDocument = HydratedDocument<Maintenance>;
+
+@Schema()
+export class Maintenance {
+  @Prop()
+  description: string;
+
+  @Prop({ type: 'ObjectId', ref: 'User' })
+  user: User;
+
+  @Prop()
+  date: Date;
+
+  @Prop({ type: 'ObjectId', ref: 'Machine' })
+  machine: Machine;
+}
+
+export const MaintenanceSchema = SchemaFactory.createForClass(Maintenance);


### PR DESCRIPTION
The code changes introduce a new file `update-maintenance.dto.ts` that defines the `UpdateMaintenanceDto` class. This class extends the `PartialType` from `@nestjs/mapped-types` and is used for performing partial updates on maintenance records. This addition allows for more flexible and granular updates to maintenance data.