### PR TITLE
feat: Update puppeteer launch options to include --no-sandbox flag

### DIFF
--- a/src/pdf/pdf.service.ts
+++ b/src/pdf/pdf.service.ts
@@ -4,7 +4,7 @@ import puppeteer from 'puppeteer';
 @Injectable()
 export class PdfService {
   async generate(html: string): Promise<Buffer> {
-    const browser = await puppeteer.launch({ headless: true });
+    const browser = await puppeteer.launch({ headless: true, args: ['--no-sandbox'] });
     const page = await browser.newPage();
     await page.setContent(html);
 


### PR DESCRIPTION
The code changes in `pdf.service.ts` modify the `PdfService` class to update the launch options for puppeteer. The `headless` option remains `true`, but the `args` option now includes the `--no-sandbox` flag. This change is made to address any sandboxing issues that may occur when running puppeteer.