### PR TITLE
feat: Add SuppliesUsageModule and related DTOs, schemas, controller, …

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import { PdfService } from './pdf/pdf.service';
 import { BatchModule } from './batch/batch.module';
 import { MaintenanceModule } from './maintenance/maintenance.module';
 import { OrdersModule } from './orders/orders.module';
+import { SuppliesUsageModule } from './supplies-usage/supplies-usage.module';
 
 @Module({
   imports: [
@@ -39,6 +40,7 @@ import { OrdersModule } from './orders/orders.module';
     BatchModule,
     MaintenanceModule,
     OrdersModule,
+    SuppliesUsageModule,
   ],
   providers: [PdfService],
 })

--- a/src/supplies-usage/dto/create-supplies-usage.dto.ts
+++ b/src/supplies-usage/dto/create-supplies-usage.dto.ts
@@ -1,0 +1,12 @@
+import { IsNumber, IsDateString, IsMongoId } from 'class-validator';
+
+export class CreateSuppliesUsageDto {
+  @IsNumber()
+  quantity: number;
+
+  @IsMongoId()
+  supply: string;
+
+  @IsDateString()
+  date_used: Date;
+}

--- a/src/supplies-usage/dto/update-supplies-usage.dto.ts
+++ b/src/supplies-usage/dto/update-supplies-usage.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateSuppliesUsageDto } from './create-supplies-usage.dto';
+
+export class UpdateSuppliesUsageDto extends PartialType(CreateSuppliesUsageDto) {}

--- a/src/supplies-usage/schemas/supplies-usage.schema.ts
+++ b/src/supplies-usage/schemas/supplies-usage.schema.ts
@@ -1,0 +1,19 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument } from 'mongoose';
+import { Supply } from '../../supplies/schemas/supply.schema';
+
+export type SuppliesUsageDocument = HydratedDocument<SuppliesUsage>;
+
+@Schema()
+export class SuppliesUsage {
+  @Prop()
+  quantity: number;
+
+  @Prop({ type: 'ObjectId', ref: 'Supply' })
+  supply: Supply;
+
+  @Prop()
+  date_used: Date;
+}
+
+export const SuppliesUsageSchema = SchemaFactory.createForClass(SuppliesUsage);

--- a/src/supplies-usage/supplies-usage.controller.spec.ts
+++ b/src/supplies-usage/supplies-usage.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SuppliesUsageController } from './supplies-usage.controller';
+import { SuppliesUsageService } from './supplies-usage.service';
+
+describe('SuppliesUsageController', () => {
+  let controller: SuppliesUsageController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SuppliesUsageController],
+      providers: [SuppliesUsageService],
+    }).compile();
+
+    controller = module.get<SuppliesUsageController>(SuppliesUsageController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/supplies-usage/supplies-usage.controller.ts
+++ b/src/supplies-usage/supplies-usage.controller.ts
@@ -1,0 +1,35 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { SuppliesUsageService } from './supplies-usage.service';
+import { CreateSuppliesUsageDto } from './dto/create-supplies-usage.dto';
+import { UpdateSuppliesUsageDto } from './dto/update-supplies-usage.dto';
+import { ParseObjectIdPipe } from 'src/pipes/parse-object-id-pipe.pipe';
+
+@Controller('supplies-usage')
+export class SuppliesUsageController {
+  constructor(private readonly suppliesUsageService: SuppliesUsageService) {}
+
+  @Post()
+  create(@Body() createSuppliesUsageDto: CreateSuppliesUsageDto) {
+    return this.suppliesUsageService.create(createSuppliesUsageDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.suppliesUsageService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id', ParseObjectIdPipe) id: string) {
+    return this.suppliesUsageService.findOne(id);
+  }
+
+  @Patch(':id')
+  update(@Param('id', ParseObjectIdPipe) id: string, @Body() updateSuppliesUsageDto: UpdateSuppliesUsageDto) {
+    return this.suppliesUsageService.update(id, updateSuppliesUsageDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id', ParseObjectIdPipe) id: string) {
+    return this.suppliesUsageService.remove(id);
+  }
+}

--- a/src/supplies-usage/supplies-usage.module.ts
+++ b/src/supplies-usage/supplies-usage.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { SuppliesUsageService } from './supplies-usage.service';
+import { SuppliesUsageController } from './supplies-usage.controller';
+
+@Module({
+  controllers: [SuppliesUsageController],
+  providers: [SuppliesUsageService],
+})
+export class SuppliesUsageModule {}

--- a/src/supplies-usage/supplies-usage.service.spec.ts
+++ b/src/supplies-usage/supplies-usage.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SuppliesUsageService } from './supplies-usage.service';
+
+describe('SuppliesUsageService', () => {
+  let service: SuppliesUsageService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SuppliesUsageService],
+    }).compile();
+
+    service = module.get<SuppliesUsageService>(SuppliesUsageService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/supplies-usage/supplies-usage.service.ts
+++ b/src/supplies-usage/supplies-usage.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { CreateSuppliesUsageDto } from './dto/create-supplies-usage.dto';
+import { UpdateSuppliesUsageDto } from './dto/update-supplies-usage.dto';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { SuppliesUsage } from './schemas/supplies-usage.schema';
+
+@Injectable()
+export class SuppliesUsageService {
+  constructor(
+    @InjectModel(SuppliesUsage.name)
+    private supplyUsageModel: Model<SuppliesUsage>,
+  ) {}
+
+  create(createSuppliesUsageDto: CreateSuppliesUsageDto) {
+    const supplyUsage = new this.supplyUsageModel(createSuppliesUsageDto);
+    return supplyUsage.save();
+  }
+
+  findAll() {
+    return this.supplyUsageModel.find().populate('supply');
+  }
+
+  findOne(id: string) {
+    return this.supplyUsageModel.findOne({ _id: id }).populate('supply');
+  }
+
+  async update(id: string, updateSuppliesUsageDto: UpdateSuppliesUsageDto) {
+    const suppliesUsage = await this.findOne(id);
+    if (!suppliesUsage) {
+      throw new NotFoundException('supply usage not found');
+    }
+    Object.assign(suppliesUsage, updateSuppliesUsageDto);
+    return suppliesUsage.save();
+  }
+
+  async remove(id: string) {
+    const suppliesUsage = await this.findOne(id);
+    if (!suppliesUsage) {
+      throw new NotFoundException('supply not found');
+    }
+    return this.supplyUsageModel.deleteOne({ _id: id });
+  }
+}


### PR DESCRIPTION
…and service

The code changes add a new module, `SuppliesUsageModule`, along with its related DTOs, schemas, controller, and service. This module allows for managing the usage of supplies, including creating, updating, and deleting supply usage records. The DTOs define the structure of the data sent to and received from the API endpoints. The schemas define the structure of the data stored in the database. The controller handles the incoming requests and delegates the processing to the service. The service interacts with the database and performs the necessary operations. This addition enhances the functionality of the application by providing a way to track and manage supplies usage.